### PR TITLE
Relax "Windows RT" checks for devices that are "Windows RT 8.1"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name='user-agents',
-    version='0.3.1',
+    version='0.3.2',
     author='Selwin Ong',
     author_email='selwin.ong@gmail.com',
     packages=['user_agents'],

--- a/user_agents/__init__.py
+++ b/user_agents/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 3, 1)
+VERSION = (0, 3, 2)
 
 from .parsers import parse

--- a/user_agents/parsers.py
+++ b/user_agents/parsers.py
@@ -146,7 +146,7 @@ class UserAgent(object):
             return True
         if (self.os.family == 'Android' and self._is_android_tablet()):
             return True
-        if self.os.family == 'Windows RT':
+        if self.os.family.startswith('Windows RT'):
             return True
         return False
 
@@ -178,7 +178,7 @@ class UserAgent(object):
             return True
         if self.device.family in TOUCH_CAPABLE_DEVICE_FAMILIES:
             return True
-        if self.os.family == 'Windows 8' and 'Touch' in self.ua_string:
+        if self.os.family.startswith('Windows 8') and 'Touch' in self.ua_string:
             return True
         if 'BlackBerry' in self.os.family and self._is_blackberry_touch_capable_device():
             return True


### PR DESCRIPTION
Windows tablets are not detected as being "touch capable" or "tablet", which obviously is wrong.

Maybe this could be fixed at a lower level in `ua_parser` package, but the regexp with its os replacement is explicitly stating the version, so I guess it was the intention.