### PR TITLE
Pin ua-parser to <0.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ python:
   - "3.4"
 install:
   - "python setup.py install"
-  - "pip install pyyaml ua-parser"
+  - "pip install pyyaml 'ua-parser<0.4.0'"
 script:
   - python -m unittest discover

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     package_data={'': ['README.rst']},
-    install_requires=['ua-parser'],
+    install_requires=['ua-parser<0.4.0'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',


### PR DESCRIPTION
`ua-parser` `0.4.0` has just been released, and the lack of pinning here breaks apps that don't explicitly pin their dependencies. Don't know if this is the right place / way to pin this, but it would definitely improve the situation.