### PR TITLE
Explicit version of ua-parser in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     package_data={'': ['README.rst']},
-    install_requires=['ua-parser'],
+    install_requires=['ua-parser==0.4.1'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',


### PR DESCRIPTION
It should be controllable which version of `ua-parser` is installing