### PR TITLE
Fix Firefox Tablet classification.

### DIFF
--- a/user_agents/parsers.py
+++ b/user_agents/parsers.py
@@ -141,10 +141,10 @@ class UserAgent(object):
     def _is_android_tablet(self):
         # Newer Android tablets don't have "Mobile" in their user agent string,
         # older ones like Galaxy Tab still have "Mobile" though they're not
-        if ('Mobile Safari' not in self.ua_string and
-                self.browser.family != "Firefox Mobile"):
-            return True
-        return False
+        if ('Mobile Safari' in self.ua_string or
+            (self.browser.family == 'Firefox Mobile' and 'Tablet' not in self.ua_string)):
+            return False
+        return True
 
     def _is_blackberry_touch_capable_device(self):
         # A helper to determine whether a BB phone has touch capabilities
@@ -165,7 +165,7 @@ class UserAgent(object):
             return True
         if self.os.family.startswith('Windows RT'):
             return True
-        if self.os.family == 'Firefox OS' and 'Mobile' not in self.browser.family:
+        if self.os.family == 'Firefox OS' and 'Tablet;' in self.ua_string:
             return True
         return False
 


### PR DESCRIPTION
With the latest uap-core changes, Firefox for Android on tablets is
identified as Firefox Mobile and therefore we need to update code to
check if device is Mobile or Tablet.

See:
https://github.com/ua-parser/uap-core/commit/98d29ff4dbab665e380ef0c7eaeeecb6afce425c