### PR TITLE
_is_android_tablet was detecting Opera Mini as Tablet fixed now

### DIFF
--- a/user_agents/parsers.py
+++ b/user_agents/parsers.py
@@ -142,7 +142,8 @@ class UserAgent(object):
         # Newer Android tablets don't have "Mobile" in their user agent string,
         # older ones like Galaxy Tab still have "Mobile" though they're not
         if ('Mobile Safari' not in self.ua_string and
-                self.browser.family != "Firefox Mobile"):
+                self.browser.family != "Firefox Mobile"
+                and self.browser.family != "Opera Mini"):
             return True
         return False
 


### PR DESCRIPTION
Opera Mini mobile browser is wrongly detected as Tablet.
is_tablet() internally uses _is_android_tablet() which was detecting "Opera Mini" as Tablet, this is fixed in this pull request.
