### PR TITLE
Fix reStructuredText syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,7 @@ Installation
    :alt: Build status
 
    Build status
+
 ``user-agents`` is hosted on
 `PyPI <http://pypi.python.org/pypi/user-agents/>`__ and can be installed
 as such:


### PR DESCRIPTION
It only adds an empty line to avoid the error message 
"README.rst:23: (WARNING/2) Explicit markup ends without a blank line; unexpected unindent." when conversion from README.rst to README.html is done with rst2html.py

Fixing this error should transform the raw description in Pypi (https://pypi.python.org/pypi/user-agents/)  by a HTML one.
