### PR TITLE
Simplify install documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,5 @@ python:
   - "3.7"
 install:
   - "python setup.py install"
-  - "pip install -U pip"
-  - "pip install pyyaml ua-parser"
 script:
   - python -m unittest discover

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,10 @@ as such:
 Alternatively, you can also get the latest source code from
 Github_ and install it manually.
 
+::
+
+    python setup.py install
+
 .. _Github: https://github.com/selwin/python-user-agents
 
 Usage

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ as such:
 
 ::
 
-    pip install pyyaml ua-parser user-agents
+    pip install user-agents
 
 Alternatively, you can also get the latest source code from
 Github_ and install it manually.


### PR DESCRIPTION
The README file requested to install all the project's dependencies separately, but this is actually not needed. The dependencies are listed in the `setup.py` file, and will be automatically installed, whether it is via a `pip install user-agents` or a `python setup.py install`.

Tested on a clean virtualenv, with both python2.7 and python3.7.

Note: `pyyaml` was listed as a dependency, but it looks like it is only a "setup dependency" to `ua-parser`, and is consequently not a requirement for this project.