### PR TITLE
Set is_pc Property to False for Chromecast and Vizio SmartCast Devices

### DIFF
--- a/user_agents/parsers.py
+++ b/user_agents/parsers.py
@@ -261,6 +261,8 @@ class UserAgent(object):
             return False
         if 'Chrome OS' in self.os.family:
             return True
+        if 'Chromecast' in self.os.family:
+            return False
         if 'Linux' in self.ua_string and 'X11' in self.ua_string:
             return True
         return False


### PR DESCRIPTION
Fixes https://github.com/selwin/python-user-agents/issues/121

